### PR TITLE
use tagged image series in production Dockerfile

### DIFF
--- a/1.8/prod/Dockerfile
+++ b/1.8/prod/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM bitnami/java:latest as development
+FROM bitnami/java:1.8 as development
 
 FROM bitnami/minideb:jessie
 LABEL maintainer "Bitnami <containers@bitnami.com>"


### PR DESCRIPTION
Production Dockerfile should use the tagged release series and not the `latest` tag. 